### PR TITLE
feat: add CRUD operations for `notes`, code refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .env
 .idea
 
+roadmap.md
 Cargo.lock

--- a/.sqlx/query-82feadd8402203d4a7ee1d87bce18d0ed53cc718211e1ab04fc1a005c3810c8d.json
+++ b/.sqlx/query-82feadd8402203d4a7ee1d87bce18d0ed53cc718211e1ab04fc1a005c3810c8d.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO users (name,email,password) VALUES ($1, $2, $3) RETURNING *",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "82feadd8402203d4a7ee1d87bce18d0ed53cc718211e1ab04fc1a005c3810c8d"
+}

--- a/.sqlx/query-843923b9a0257cf80f1dff554e7dc8fdfc05f489328e8376513124dfb42996e3.json
+++ b/.sqlx/query-843923b9a0257cf80f1dff554e7dc8fdfc05f489328e8376513124dfb42996e3.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM users WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "843923b9a0257cf80f1dff554e7dc8fdfc05f489328e8376513124dfb42996e3"
+}

--- a/.sqlx/query-f3f58600e971f1be6cbe206bba24f77769f54c6230e28f5b3dc719b869d9cb3f.json
+++ b/.sqlx/query-f3f58600e971f1be6cbe206bba24f77769f54c6230e28f5b3dc719b869d9cb3f.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM users WHERE email = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "f3f58600e971f1be6cbe206bba24f77769f54c6230e28f5b3dc719b869d9cb3f"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bytes",
  "futures-util",
  "http",
@@ -323,6 +324,18 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -590,6 +603,15 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2153bd83ebc09db15bcbdc3e2194d901804952e3dc96967e1cd3b0c5c32d112"
 dependencies = [
  "serde",
 ]
@@ -1315,11 +1337,13 @@ dependencies = [
  "axum-extra",
  "chrono",
  "dotenv",
+ "email_address",
  "jsonwebtoken",
  "log",
  "pretty_env_logger",
  "rand 0.9.0-alpha.1",
  "rand_core 0.6.4",
+ "regex",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7.5"
+axum = { version = "0.7.5", features = ["macros"] }
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "full"] }
 rand = "0.9.0-alpha.1"
 serde = { version = "1.0.202", features = ["derive"] }
@@ -23,3 +23,5 @@ sqlx = { version = "0.7.4", features = ["runtime-async-std-native-tls", "postgre
 jsonwebtoken = "9.3.0"
 argon2 = "0.5.3"
 rand_core = { version = "0.6.4", features = ["std"] }
+regex = "1.10.4"
+email_address = "0.2.4"

--- a/migrations/20240514124735_init.up.sql
+++ b/migrations/20240514124735_init.up.sql
@@ -4,7 +4,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TABLE "users" (
     id UUID NOT NULL PRIMARY KEY DEFAULT (uuid_generate_v4()),
-    name VARCHAR(100) NOT NULL,
+    name VARCHAR(100) NOT NULL UNIQUE,
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(100) NOT NULL,
     created_at TIMESTAMP

--- a/migrations/20240522125320_users_table_with_notes_and_relation_one-to-many.down.sql
+++ b/migrations/20240522125320_users_table_with_notes_and_relation_one-to-many.down.sql
@@ -1,0 +1,3 @@
+-- Add down migration script here
+
+DROP TABLE IF EXISTS "notes";

--- a/migrations/20240522125320_users_table_with_notes_and_relation_one-to-many.up.sql
+++ b/migrations/20240522125320_users_table_with_notes_and_relation_one-to-many.up.sql
@@ -1,0 +1,22 @@
+-- Add up migration script here
+
+-- Ensure the uuid-ossp extension is available for UUID generation
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Create the notes table
+CREATE TABLE "notes" (
+     id UUID NOT NULL PRIMARY KEY DEFAULT (uuid_generate_v4()),
+     author_id UUID NOT NULL,
+     author_name VARCHAR(100) NOT NULL,
+     title VARCHAR(255) NOT NULL,
+     text TEXT NOT NULL,
+     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+     CONSTRAINT fk_author
+         FOREIGN KEY(author_id)
+             REFERENCES users(id)
+             ON DELETE CASCADE
+);
+
+-- Create an index on author_id for faster lookup
+CREATE INDEX notes_author_id_idx ON notes (author_id);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,23 +1,21 @@
 use std::sync::Arc;
 
 use argon2::{password_hash::SaltString, Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
-use axum::{
-    extract::State,
-    http::{header, Response, StatusCode},
-    response::IntoResponse,
-    Extension, Json,
-};
+use axum::{debug_handler, extract::{State, Json, Extension}, http::{header, Response, StatusCode}, response::IntoResponse};
+use axum::extract::Path;
 use axum_extra::extract::cookie::{Cookie, SameSite};
+use email_address::EmailAddress;
 use jsonwebtoken::{encode, EncodingKey, Header};
 use rand_core::OsRng;
 use serde_json::{json, Value};
-use sqlx::query_as;
+use sqlx::{Postgres, query_as, QueryBuilder};
+use uuid::Uuid;
 
 use crate::{
-    model::{LoginUserSchema, RegisterUserSchema, TokenClaims, User},
-    response::FilteredUser,
+    model::*,
     AppState,
-    jwt_auth::ErrorResponse,
+    response::{FilteredUser, filter_user_record},
+    utils::{is_password_valid, is_username_valid},
 };
 
 pub async fn register_user_handler(
@@ -26,7 +24,7 @@ pub async fn register_user_handler(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     let user_exists: Option<bool> =
         sqlx::query_scalar("SELECT EXISTS( SELECT 1 FROM users WHERE email = $1)")
-            .bind(body.email.to_string().to_ascii_lowercase())
+            .bind(body.email.trim().to_string().to_ascii_lowercase())
             .fetch_one(&data.db)
             .await
             .map_err(|err| {
@@ -47,9 +45,33 @@ pub async fn register_user_handler(
         }
     }
 
+    if !EmailAddress::is_valid(&body.email.trim().to_ascii_lowercase()) {
+        let error_response = json!({
+            "status": "fail",
+            "message": "User's email address is not valid"
+        });
+        return Err((StatusCode::BAD_REQUEST, Json(error_response)));
+    }
+
+    if !is_username_valid(body.name.trim()) {
+        let error_response = json!({
+            "status": "fail",
+            "message": "Username is not valid"
+        });
+        return Err((StatusCode::BAD_REQUEST, Json(error_response)));
+    }
+
+    if !is_password_valid(body.password.trim()) {
+        let error_response = json!({
+            "status": "fail",
+            "message": "User's password is not valid"
+        });
+        return Err((StatusCode::BAD_REQUEST, Json(error_response)));
+    }
+
     let salt = SaltString::generate(&mut OsRng);
     let hashed_password = Argon2::default()
-        .hash_password(body.password.as_bytes(), &salt)
+        .hash_password(body.password.trim().as_bytes(), &salt)
         .map_err(|e| {
             let error_response = json!({
                 "status": "fail",
@@ -61,8 +83,8 @@ pub async fn register_user_handler(
     let user = sqlx::query_as!(
         User,
         "INSERT INTO users (name,email,password) VALUES ($1, $2, $3) RETURNING *",
-        body.name.to_string(),
-        body.email.to_string().to_ascii_lowercase(),
+        body.name.trim().to_string(),
+        body.email.trim().to_string().to_ascii_lowercase(),
         hashed_password
     )
         .fetch_one(&data.db)
@@ -71,7 +93,7 @@ pub async fn register_user_handler(
             let error_response = json!({
             "status": "fail",
             "message": format!("Database error: {}", e),
-        });
+            });
             (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
         })?;
 
@@ -88,8 +110,8 @@ pub async fn login_user_handler(
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     let user = query_as!(
         User,
-        "SELECT * FROM USERS WHERE email = $1",
-        body.email.to_ascii_lowercase()
+        "SELECT * FROM users WHERE name = $1",
+        body.name.trim().to_ascii_lowercase()
     ).fetch_optional(&data.db)
         .await
         .map_err(|err| {
@@ -109,14 +131,14 @@ pub async fn login_user_handler(
 
     let is_valid = match PasswordHash::new(&user.password) {
         Ok(parsed_hash) => Argon2::default().verify_password(body.password.as_bytes(), &parsed_hash)
-            .map_or(false, |_| true),
+            .map_or(false, |()| true),
         Err(_) => false
     };
 
     if !is_valid {
         let error_response = json!({
             "status": "fail",
-            "message": "Invalid email or password"
+            "message": "Invalid name or password"
         });
         return Err((StatusCode::BAD_REQUEST, Json(error_response)));
     }
@@ -137,7 +159,7 @@ pub async fn login_user_handler(
     )
         .unwrap();
 
-    let cookie = Cookie::build(("token", token.to_owned()))
+    let cookie = Cookie::build(("token", token.clone()))
         .path("/")
         .max_age(time::Duration::hours(1))
         .same_site(SameSite::Lax)
@@ -168,15 +190,204 @@ pub async fn logout_handler() -> Result<impl IntoResponse, (StatusCode, Json<ser
 }
 
 pub async fn get_me_handler(
-    Extension(user): Extension<User>
+    Extension(user): Extension<FilteredUser>
 ) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
     let json_response = json!({
         "status": "success",
         "data": {
-            "user": filter_user_record(&user)
+            "user": &user,
         }
     });
     Ok(Json(json_response))
+}
+
+#[debug_handler]
+pub async fn create_note_handler(
+    State(data): State<Arc<AppState>>,
+    Extension(user): Extension<FilteredUser>,
+    Json(body): Json<CreateNoteSchema>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    if body.title.trim().is_empty() {
+        let error_response = json!({
+            "status": "fail",
+            "message": "Title can't be blank"
+        });
+        return Err((StatusCode::BAD_REQUEST, Json(error_response)));
+    }
+    if body.text.trim().is_empty() {
+        let error_response = json!({
+            "status": "fail",
+            "message": "Text can't be blank"
+        });
+        return Err((StatusCode::BAD_REQUEST, Json(error_response)));
+    }
+    let note = query_as!(
+        Note,
+        "INSERT INTO notes (author_id,author_name,title,text) VALUES ($1, $2, $3, $4) RETURNING *",
+        Uuid::parse_str(&user.id).unwrap(),
+        user.name,
+        body.title,
+        body.text,
+    )
+        .fetch_one(&data.db)
+        .await
+        .map_err(|e| {
+            let error_response = json!({
+                "status": "fail",
+                "message": format!("Database error: {}", e),
+            });
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
+        })?;
+
+    let note_response = json!({
+        "status": "success",
+        "data": {
+            "note": note,
+        },
+    });
+    Ok(Json(note_response))
+}
+
+pub async fn get_notes_handler(
+    State(data): State<Arc<AppState>>,
+    Extension(user): Extension<FilteredUser>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let notes = query_as!(
+        Note,
+        "SELECT * FROM notes WHERE author_id = $1",
+        Uuid::parse_str(&user.id).unwrap(),
+    )
+        .fetch_all(&data.db)
+        .await
+        .map_err(|e| {
+            let error_response = json!({
+                "status": "fail",
+                "message": format!("Database error: {}", e),
+            });
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
+        })?;
+
+    let note_response = json!({
+        "status": "success",
+        "data": {
+            "note": notes,
+        },
+    });
+    Ok(Json(note_response))
+}
+
+pub async fn get_note_handler(
+    State(data): State<Arc<AppState>>,
+    Extension(user): Extension<FilteredUser>,
+    Path(note_id): Path<Uuid>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let note = query_as!(
+        Note,
+        "SELECT * FROM notes WHERE author_id = $1 AND id = $2",
+        Uuid::parse_str(&user.id).unwrap(),
+        note_id
+    )
+        .fetch_one(&data.db)
+        .await
+        .map_err(|e| {
+            let error_response = json!({
+                "status": "fail",
+                "message": format!("Database error: {}", e),
+            });
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
+        })?;
+
+    let note_response = json!({
+        "status": "success",
+        "data": {
+            "note": note,
+        },
+    });
+    Ok(Json(note_response))
+}
+
+pub async fn update_note_handler(
+    State(data): State<Arc<AppState>>,
+    Path(note_id): Path<Uuid>,
+    Extension(user): Extension<FilteredUser>,
+    Json(body): Json<UpdateNoteSchema>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    if body.title.is_none() && body.text.is_none() {
+        let error_response = json!({
+            "status": "fail",
+            "message": "No field provided to update"
+        });
+        return Err((StatusCode::BAD_REQUEST, Json(error_response)));
+    }
+
+    let mut query_str: QueryBuilder<Postgres> = QueryBuilder::new("UPDATE notes SET ");
+
+    if body.title.is_some() {
+        query_str.push("title = ");
+        query_str.push_bind(body.title.unwrap());
+        query_str.push(", ");
+    }
+
+    if body.text.is_some() {
+        query_str.push("text = ");
+        query_str.push_bind(body.text.unwrap());
+    }
+
+    query_str.push(" WHERE id = ");
+    query_str.push_bind(note_id);
+    query_str.push(" AND author_id = ");
+    query_str.push_bind(user.id);
+    query_str.push(" RETURNING *;");
+
+    let note: Note = query_str
+        .build_query_as()
+        .fetch_one(&data.db)
+        .await
+        .map_err(|e| {
+            let error_response = json!({
+                "status": "fail",
+                "message": format!("Database error: {}", e),
+            });
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
+        })?;
+
+    let note_response = json!({
+        "status": "success",
+        "data": {
+            "note": note,
+        },
+    });
+    Ok(Json(note_response))
+}
+
+pub async fn delete_note_handler(
+    State(data): State<Arc<AppState>>,
+    Extension(user): Extension<FilteredUser>,
+    Path(note_id): Path<Uuid>,
+) -> Result<impl IntoResponse, (StatusCode, Json<Value>)> {
+    let note = query_as!(
+        Note,
+        "DELETE FROM notes WHERE id = $1 AND author_id = $2 RETURNING *;",
+        note_id,
+        Uuid::parse_str(&user.id).unwrap()
+    )
+        .fetch_one(&data.db)
+        .await
+        .map_err(|e| {
+            let error_response = json!({
+                "status": "fail",
+                "message": format!("Database error: {}", e),
+            });
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(error_response))
+        })?;
+
+    let note_response = json!({
+        "status": "success",
+        "data": {
+            "note": note,
+        },
+    });
+    Ok(Json(note_response))
 }
 
 pub async fn health_checker_handler() -> impl IntoResponse {
@@ -188,14 +399,4 @@ pub async fn health_checker_handler() -> impl IntoResponse {
     });
 
     Json(json_response)
-}
-
-fn filter_user_record(user: &User) -> FilteredUser {
-    FilteredUser {
-        id: user.id.to_string(),
-        name: user.name.to_string(),
-        email: user.email.to_string(),
-        createdAt: user.created_at.unwrap(),
-        updatedAt: user.updated_at.unwrap(),
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,24 +4,24 @@ mod config;
 mod response;
 mod jwt_auth;
 mod handler;
+mod utils;
 
-use std::env;
 use std::sync::Arc;
-use axum::response::IntoResponse;
-use axum::{Json, Router};
-use axum::http::{HeaderValue, Method};
-use axum::http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
-use axum::routing::{get, post};
 use dotenv::dotenv;
 use log::info;
-use rand::random;
-use serde_json::json;
-use sqlx::{Pool, Postgres};
-use sqlx::postgres::PgPoolOptions;
-use tower_http::cors::{Any, CorsLayer};
-use crate::config::Config;
-use crate::handler::{login_user_handler, register_user_handler};
-use crate::route::create_router;
+use tower_http::cors::{CorsLayer};
+use axum::{
+    http::{HeaderValue, Method,header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE}}
+};
+use sqlx::{
+    Pool,
+    Postgres,
+    postgres::PgPoolOptions,
+};
+use crate::{
+    config::Config,
+    route::create_router
+};
 
 pub struct AppState {
     db: Pool<Postgres>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,6 @@ use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[allow(non_snake_case)]
 #[derive(Debug, Deserialize, sqlx::FromRow, Serialize, Clone)]
 pub struct User {
     pub id: Uuid,
@@ -29,6 +28,7 @@ pub struct Note {
     #[serde(rename = "updatedAt")]
     pub updated_at: Option<DateTime<Utc>>,
 }
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TokenClaims {
     pub sub: String,
@@ -45,6 +45,18 @@ pub struct RegisterUserSchema {
 
 #[derive(Debug, Deserialize)]
 pub struct LoginUserSchema {
-    pub email: String,
+    pub name: String,
     pub password: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateNoteSchema {
+    pub title: String,
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateNoteSchema {
+    pub title: Option<String>,
+    pub text: Option<String>,
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,8 +1,9 @@
 use chrono::prelude::*;
 use serde::Serialize;
+use crate::model::User;
 
 #[allow(non_snake_case)]
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct FilteredUser {
     pub id : String,
     pub name: String,
@@ -19,4 +20,14 @@ pub struct UserData {
 pub struct UserResponse {
     pub status: String,
     pub data: UserData,
+}
+
+pub fn filter_user_record(user: &User) -> FilteredUser {
+    FilteredUser {
+        id: user.id.to_string(),
+        name: user.name.to_string(),
+        email: user.email.to_string(),
+        createdAt: user.created_at.unwrap(),
+        updatedAt: user.updated_at.unwrap(),
+    }
 }

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,9 +1,15 @@
 use std::sync::Arc;
-use axum::{middleware, Router};
-use axum::routing::{get, post};
-use crate::handler::{get_me_handler, health_checker_handler, login_user_handler, logout_handler, register_user_handler};
-use crate::{AppState};
-use crate::jwt_auth::auth;
+
+use axum::{
+    middleware,
+    Router,
+    routing::{delete, get, patch, post}
+};
+use crate::{
+    AppState,
+    handler::*,
+    jwt_auth::auth,
+};
 
 pub fn create_router(app_state: Arc<AppState> ) -> Router {
     Router::new()
@@ -19,6 +25,31 @@ pub fn create_router(app_state: Arc<AppState> ) -> Router {
             "/api/users/me",
             get(get_me_handler)
                 .route_layer(middleware::from_fn_with_state(app_state.clone(), auth)),
+        )
+        .route(
+            "/api/notes/",
+            post(create_note_handler)
+                .route_layer(middleware::from_fn_with_state(app_state.clone(), auth)),
+        )
+        .route(
+            "/api/notes/",
+            get(get_notes_handler)
+                .route_layer(middleware::from_fn_with_state(app_state.clone(), auth))
+        )
+        .route(
+            "/api/notes/:note_id",
+            get(get_note_handler)
+                .route_layer(middleware::from_fn_with_state(app_state.clone(), auth)),
+        )
+        .route(
+            "/api/notes/:note_id",
+            patch(update_note_handler)
+                .route_layer(middleware::from_fn_with_state(app_state.clone(), auth))
+        )
+        .route(
+            "/api/notes/:note_id",
+            delete(delete_note_handler)
+                .route_layer(middleware::from_fn_with_state(app_state.clone(), auth))
         )
         .with_state(app_state)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,7 @@
+pub fn is_password_valid(password: &str) -> bool {
+    password.trim().len() >= 5
+}
+
+pub fn is_username_valid(username: &str) -> bool {
+    username.trim().len() >= 5
+}


### PR DESCRIPTION
1. Added new SQL migration files for database initialization 1. Init file with 'notes' table that references to 'users' (1-to-many) 2. Drop file for dropping this table.
2. Updated modules: handler.rs, model.rs, response.rs, route.rs 
    - handler.rs: Add new handler that implements CRUD for 'notes' 
      -  `create_note_handler`: Creates a new note. Validates non-blank title and text. Handles database errors. 
      - `get_notes_handler`: Retrieves all notes for the authenticated user. Handles database errors. 
      - `get_note_handler`: Fetches a specific note by ID for the authenticated user. Handles database errors. 
      - `update_note_handler`: Updates a specific note by ID. Requires at least one field (title or text) to be provided. Handles database errors. 
      - `delete_note_handler`: Deletes a specific note by ID for the authenticated user. Handles database errors. 
    - route.rs: 
    - Added new routes for 'notes' `/api/notes/``: 
      - POST: create_note_handler - Creates a new note. Requires authentication. 
      - GET: get_notes_handler - Retrieves all notes for the authenticated user. Requires authentication. 
    - `/api/notes/:note_id``: 
      - GET: get_note_handler - Fetches a specific note by ID for the authenticated user. Requires authentication. 
      - PATCH: update_note_handler - Updates a specific note by ID. Requires at least one field (title or text) to be provided. Requires authentication. 
      - DELETE: delete_note_handler - Deletes a specific note by ID for the authenticated user. Requires authentication.